### PR TITLE
Mount Bolt as a sub-app

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@slack/bolt": "^1.0.1",
     "compression": "^1.7.1",
+    "express": "^4.16.4",
     "sirv": "^0.4.0"
   },
   "devDependencies": {

--- a/src/slack/index.js
+++ b/src/slack/index.js
@@ -1,6 +1,13 @@
-/**
- * @param {import("@slack/bolt").App} app
- */
-export function add_slack_events(app) {
-	app.use(({ context }) => (context.client = app.client));
-}
+import { App } from '@slack/bolt';
+
+const { SLACK_SIGNING_SECRET, SLACK_BOT_TOKEN } = process.env;
+
+const app = new App({
+	token: SLACK_BOT_TOKEN,
+	signingSecret: SLACK_SIGNING_SECRET
+});
+
+app.use(({ context }) => (context.client = app.client));
+
+export const slack_middleware = app.receiver.app;
+export const slack_client = app.client;


### PR DESCRIPTION
Create a host Express app manually and mount the Express app provided by `@slack/bolt` as a sub-app. This provides cleaner organization of of Slack webhook-related code separate from the main server startup.