### PR TITLE
Ingest postal dode data

### DIFF
--- a/.eslintrc.restrictions.js
+++ b/.eslintrc.restrictions.js
@@ -31,7 +31,7 @@ const restrictions = {
 	],
 	pg: [
 		{
-			selector: 'ImportDeclaration .source[value=/^pg/]',
+			selector: 'ImportDeclaration .source[value=/^pg$/]',
 			message: "Unexpected usage of the 'pg' package."
 		}
 	],

--- a/package-lock.json
+++ b/package-lock.json
@@ -5664,6 +5664,11 @@
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
       "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
     },
+    "pg-copy-streams": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-copy-streams/-/pg-copy-streams-2.2.0.tgz",
+      "integrity": "sha512-w1gy/KAD49vaCCUfqcjh4fy1V4TF6fvtZ+EaRAU0QKtADMxihb+qYRgbWTDbi6Lh6v31CsWC0ru8vCDHofrRQQ=="
+    },
     "pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1655,8 +1655,7 @@
     "buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-      "dev": true
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -2236,6 +2235,11 @@
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
       "dev": true
+    },
+    "csv-parse": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.4.1.tgz",
+      "integrity": "sha512-uFe5phPfmwBXSPWz5GYHeaEc2Oezn2kY5iLIvG1sJjc32Y4GU7T/b/uX5ffZh4CBDWwJQjwAuxrDEdl3Z5Qv+g=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -5626,8 +5630,7 @@
     "pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
-      "dev": true
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
     },
     "performance-now": {
       "version": "2.1.0",
@@ -8902,7 +8905,6 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
-      "dev": true,
       "requires": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
@@ -8912,7 +8914,6 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
           "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
-          "dev": true,
           "requires": {
             "pend": "~1.2.0"
           }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "http-errors": "^1.7.2",
     "luxon": "^1.15.0",
     "pg": "^7.11.0",
+    "pg-copy-streams": "^2.2.0",
     "pino": "^5.12.5",
     "pino-http": "^4.2.0",
     "polka": "^1.0.0-next.3",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@slack/web-api": "^5.0.1",
     "accepts": "^1.3.7",
     "connect-redis": "^3.4.1",
+    "csv-parse": "^4.4.1",
     "express-session": "^1.16.1",
     "http-errors": "^1.7.2",
     "luxon": "^1.15.0",
@@ -44,7 +45,8 @@
     "redis": "^2.8.0",
     "sirv": "^0.4.2",
     "squid": "^0.4.0",
-    "uid-safe": "^2.1.5"
+    "uid-safe": "^2.1.5",
+    "yauzl": "^2.10.0"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/src/server/logger.js
+++ b/src/server/logger.js
@@ -26,8 +26,8 @@ try {
 	process.exit(EXIT_CODE_LOGGER_ERROR);
 }
 
-export function get_logger(name) {
-	return logger.child({ name });
+export function get_logger(name, bindings) {
+	return logger.child({ name, ...bindings });
 }
 
 logger.info('Logger created and ready for use');

--- a/src/server/postal-codes/get-file-stream.js
+++ b/src/server/postal-codes/get-file-stream.js
@@ -33,7 +33,8 @@ export async function get_zip_entry(zip_url) {
 	logger.debug('Opening entry stream...');
 	const open = promisify(archive.openReadStream).bind(archive);
 	const zip_stream = await open(entry);
-	logger.debug('Successfully opened entry stream');
+	logger.debug('Opened entry stream');
 
+	logger.info('Got ZIP entry, returning stream');
 	return zip_stream;
 }

--- a/src/server/postal-codes/index.js
+++ b/src/server/postal-codes/index.js
@@ -1,5 +1,7 @@
 import { postal_codes } from '../queries/models';
-import { get_csv_rows } from './stream-pipeline';
+import { get_logger } from '../logger';
+import { get_zip_entry } from './get-file-stream';
+import create_csv_parser from 'csv-parse';
 
 const ZIP_URL = 'https://download.geonames.org/export/zip/allCountries.zip';
 const PARSE_OPTIONS = {
@@ -9,5 +11,30 @@ const PARSE_OPTIONS = {
 };
 
 export async function* get_postal_codes() {
-	yield* get_csv_rows(ZIP_URL, PARSE_OPTIONS);
+	let logger = get_logger('ingest-postal-codes');
+	logger.info('Retrieving postal codes');
+
+	const parser = create_csv_parser(PARSE_OPTIONS);
+
+	logger.debug('Retrieving zip entry stream');
+	const entry_stream = await get_zip_entry(ZIP_URL);
+	logger.debug('Got zip entry stream');
+
+	let entry_error;
+	entry_stream.on('error', error => {
+		entry_error = error;
+		parser.end();
+	});
+
+	logger.debug('Piping entry stream to parser and yielding');
+	yield* entry_stream.pipe(parser);
+	logger = logger.child({ parser_info: parser.info });
+	logger.debug('Parser stream ended');
+
+	if (entry_error) {
+		logger.error({ error: entry_error }, 'Encountered error during processing');
+		throw entry_error;
+	}
+
+	logger.info('Processed and yielded %s CSV records', parser.info.records);
 }

--- a/src/server/postal-codes/index.js
+++ b/src/server/postal-codes/index.js
@@ -1,0 +1,13 @@
+import { postal_codes } from '../queries/models';
+import { get_csv_rows } from './stream-pipeline';
+
+const ZIP_URL = 'https://download.geonames.org/export/zip/allCountries.zip';
+const PARSE_OPTIONS = {
+	columns: Object.keys(postal_codes.columns),
+	delimiter: '\t',
+	quote: false
+};
+
+export async function* get_postal_codes() {
+	yield* get_csv_rows(ZIP_URL, PARSE_OPTIONS);
+}

--- a/src/server/postal-codes/network-reader.js
+++ b/src/server/postal-codes/network-reader.js
@@ -1,0 +1,115 @@
+import https from 'https';
+import { Readable } from 'stream';
+import { RandomAccessReader } from 'yauzl';
+import { get_logger } from '../logger';
+import { ResponseValidator } from './response-validator';
+
+function outgoing_request_serializer(req) {
+	return {
+		method: req.method,
+		path: req.path,
+		headers: req.getHeaders()
+	};
+}
+
+function incoming_response_serializer(res) {
+	const connection = res.connection;
+	return {
+		headers: res.headers,
+		statusCode: res.statusCode,
+		remoteAddress: connection && connection.remoteAddress,
+		remotePort: connection && connection.remotePort
+	};
+}
+
+const HTTP_SERIALIZERS = {
+	req: outgoing_request_serializer,
+	res: incoming_response_serializer
+};
+
+const SUPPORTED_PROTOCOL = https.globalAgent.protocol;
+
+export class NetworkRandomAccessReader extends RandomAccessReader {
+	#url;
+	#logger;
+	#total_size;
+
+	constructor(url) {
+		super();
+		this.#url = new URL(url);
+
+		const protocol = this.#url.protocol;
+		if (protocol !== SUPPORTED_PROTOCOL) {
+			throw new Error(`Unsupported protocol: ${protocol}`);
+		}
+
+		this.#logger = get_logger('yauzl:network-reader', {
+			zip_url: this.#url,
+			serializers: HTTP_SERIALIZERS
+		});
+	}
+
+	async get_total_size() {
+		this.#logger.debug('Requesting total size of zip file...');
+
+		let total = this.#total_size;
+		if (total) {
+			this.#logger.debug({ total }, 'Total size already calculated');
+			return total;
+		}
+
+		const options = { method: 'HEAD' };
+
+		let req;
+		const res = await new Promise((resolve, reject) => {
+			req = https.request(this.#url, options, resolve);
+			this.#logger.debug({ req }, 'Sending request...');
+			req.once('error', reject).end();
+		});
+
+		this.#logger.debug({ req, res }, 'Got response, validating metadata...');
+		const validator = new ResponseValidator(res);
+		validator.expect_status(200);
+		validator.expect_accept_ranges();
+		total = validator.expect_content_length();
+		validator.expect_content_type();
+
+		this.#logger.debug({ req, res, total }, 'Retrieved total zip file size');
+		this.#total_size = total;
+		return total;
+	}
+
+	async *request_range(start, end) {
+		const total = this.#total_size;
+		const logger = this.#logger.child({ start, end, total });
+		logger.debug('Requesting byte range');
+
+		const true_end = end - 1; // the given `end` value is exclusive
+		const options = {
+			method: 'GET',
+			headers: { range: `bytes=${start}-${true_end}` }
+		};
+
+		let req;
+		const res = await new Promise((resolve, reject) => {
+			req = https.request(this.#url, options, resolve);
+			logger.debug({ req }, 'Sending request...');
+			req.once('error', reject).end();
+		});
+
+		logger.debug({ req, res }, 'Got response, validating metadata...');
+		const validator = new ResponseValidator(res);
+		validator.expect_status(206);
+		validator.expect_content_range('bytes', start, true_end, total);
+		validator.expect_content_length(end - start);
+		validator.expect_content_type();
+
+		logger.debug({ req, res }, 'Got partial response, yielding stream...');
+		yield* res;
+	}
+
+	_readStreamForRange(start, end) {
+		const iterable = this.request_range(start, end);
+		return Readable.from(iterable, { objectMode: false });
+	}
+}

--- a/src/server/postal-codes/response-validator.js
+++ b/src/server/postal-codes/response-validator.js
@@ -1,0 +1,63 @@
+import { strict as assert } from 'assert';
+
+export class ResponseValidator {
+	#res;
+
+	constructor(res) {
+		this.#res = res;
+	}
+
+	expect_status(code) {
+		assert.equal(this.#res.statusCode, code, 'Unexpected status code');
+	}
+
+	expect_accept_ranges(unit = 'bytes') {
+		const raw = this.#res.headers['accept-ranges'];
+		assert.ok(raw, 'No Accept-Ranges header is present');
+		assert.equal(raw, unit, 'Unexpected Accept-Ranges header');
+	}
+
+	parse_content_range(raw) {
+		const match = /(\w+) (\d+)-(\d+)\/(\d+)/.exec(raw);
+		assert.ok(match, `Malformed Content-Range header: ${raw}`);
+		// eslint-disable-next-line no-unused-vars
+		const [_entire_match, unit, start, end, total] = match;
+		return {
+			unit,
+			start: Number.parseInt(start, 10),
+			end: Number.parseInt(end, 10),
+			total: Number.parseInt(total, 10)
+		};
+	}
+
+	expect_content_range(unit, start, end, total) {
+		const raw = this.#res.headers['content-range'];
+		assert.ok(raw, 'No Content-Range header is present');
+
+		const actual = this.parse_content_range(raw);
+		const expected = { unit, start, end, total };
+		assert.deepEqual(actual, expected, 'Unexpected Content-Range header');
+	}
+
+	expect_content_length(length = null) {
+		const raw = this.#res.headers['content-length'];
+		assert.ok(raw, 'No Content-Length header is present');
+
+		const parsed = Number.parseInt(raw, 10);
+		assert.ok(parsed, 'Malformed Content-Length header');
+		assert.equal(parsed.toString(), raw, 'Malformed Content-Length header');
+
+		if (length !== null) {
+			assert.equal(parsed, length, 'Unexpected Content-Length header');
+		}
+
+		return parsed;
+	}
+
+	expect_content_type(type = 'application/zip') {
+		const raw = this.#res.headers['content-type'];
+		assert.ok(raw, 'No Content-Type header is present');
+		assert.equal(raw, type, 'Unexpected Content-Type header');
+		return raw;
+	}
+}

--- a/src/server/postal-codes/stream-pipeline.js
+++ b/src/server/postal-codes/stream-pipeline.js
@@ -1,0 +1,66 @@
+import { strict as assert } from 'assert';
+import { promisify } from 'util';
+import { fromRandomAccessReader } from 'yauzl';
+import create_csv_parser from 'csv-parse';
+import { NetworkRandomAccessReader } from './network-reader';
+import { get_logger } from '../logger';
+
+const get_central_directory = promisify(fromRandomAccessReader);
+
+export async function* get_csv_rows(zip_url, parse_options) {
+	let logger = get_logger('csv-processor', { zip_url, parse_options });
+	logger.info('Retrieving CSV records...');
+
+	logger.debug('Retrieving total zip file size...');
+	const reader = new NetworkRandomAccessReader(zip_url);
+	const total_size = await reader.get_total_size();
+	logger.debug({ total_size }, 'Got total file size');
+
+	logger.debug({ total_size }, 'Retrieving central directory...');
+	const archive = await get_central_directory(reader, total_size);
+	logger.debug({ archive }, 'Got central directory');
+
+	assert.equal(archive.entryCount, 1, 'Expected archive to have single entry');
+
+	logger.debug({ archive }, 'Retrieving entry information...');
+	const entry = await new Promise((resolve, reject) => {
+		archive.once('entry', resolve);
+		archive.once('error', reject);
+		archive.once('end', reject);
+	});
+	logger = logger.child({ archive, entry });
+	logger.debug('Got entry information');
+
+	logger.debug('Preparing parser and error handlers...');
+	const parser = create_csv_parser(parse_options);
+	const errors = [];
+	function on_error(error) {
+		errors.push(error);
+		parser.end();
+	}
+	parser.on('error', on_error);
+	archive.on('error', on_error);
+	logger.debug('Parser and error handlers prepared');
+
+	logger.debug('Opening entry stream...');
+	const open = promisify(archive.openReadStream).bind(archive);
+	const zip_stream = await open(entry);
+	zip_stream.on('error', on_error);
+	logger.debug('Opened entry stream');
+
+	logger.debug('Piping entry stream to parser...');
+	zip_stream.pipe(parser);
+	logger.debug('Yielding parser stream...');
+	yield* parser;
+	logger = logger.child({ parser_info: parser.info });
+	logger.debug('Parser stream ended');
+
+	if (errors.length > 0) {
+		for (const error of errors) {
+			logger.error({ error }, 'Encountered error during processing');
+		}
+		throw new Error('Encountered one or more errors during processing');
+	}
+
+	logger.info('Processed and yielded %s CSV records', parser.info.records);
+}

--- a/src/server/queries/import-postal-codes.js
+++ b/src/server/queries/import-postal-codes.js
@@ -1,0 +1,97 @@
+import { sql } from 'squid/pg';
+import { from as copy } from 'pg-copy-streams';
+import { postgres_pool } from '../external-services';
+import { get_logger } from '../logger';
+
+const logger = get_logger('query:import-postal-codes');
+
+// '\b' is a backspace character (ASCII 8)
+// This effectively disables Postgres' quote processing
+const copy_query = `
+	COPY postal_codes_import
+	FROM STDIN
+	WITH (
+		FORMAT 'csv',
+		DELIMITER '\t',
+		NULL '',
+		QUOTE '\b',
+		FORCE_NOT_NULL ('place_name')
+	);
+`;
+
+export async function import_postal_codes(file_stream) {
+	logger.info('Importing postal codes from file stream...');
+
+	const file_promise = new Promise((resolve, reject) => {
+		file_stream.once('end', resolve);
+		file_stream.once('error', reject);
+	});
+
+	logger.debug('Retrieving Postgres client...');
+	const client = await postgres_pool.connect();
+	logger.debug('Got Postgres client');
+
+	logger.debug('Starting transaction...');
+	await client.query(sql`BEGIN;`);
+	logger.debug('Started transaction');
+
+	try {
+		logger.debug('Preparing import table...');
+		await client.query(sql`
+			DROP TABLE IF EXISTS postal_codes_import;
+		`);
+		await client.query(sql`
+			CREATE TABLE postal_codes_import (
+				LIKE postal_codes
+				INCLUDING ALL
+			);
+		`);
+		logger.debug('Import table prepared');
+
+		logger.debug('Creating `COPY` stream....');
+		// eslint-disable-next-line no-restricted-syntax
+		const copy_stream = client.query(copy(copy_query));
+		const copy_promise = new Promise((resolve, reject) => {
+			copy_stream.once('finish', resolve);
+			copy_stream.once('error', reject);
+		});
+		logger.debug('`COPY` stream created');
+
+		logger.debug('Piping file stream to copy stream....');
+		file_stream.pipe(copy_stream);
+		await Promise.all([file_promise, copy_promise]);
+		logger.debug('File and copy streams finished');
+
+		logger.debug('Exchanging tables...');
+		await client.query(sql`
+			DROP TABLE postal_codes;
+		`);
+
+		await client.query(sql`
+			ALTER TABLE postal_codes_import
+			RENAME TO postal_codes;
+		`);
+		logger.debug('Tables exchanged');
+
+		logger.debug('Committing transaction');
+		await client.query(sql`COMMIT;`);
+		logger.debug('Transaction committed');
+
+		logger.info('Imported postal codes successfully');
+	} catch (error) {
+		logger.error({ error }, 'Encountered error during processing');
+		logger.debug('Rolling back transaction...');
+		await client.query(sql`ROLLBACK;`);
+		logger.debug('Transaction rolled back');
+		throw error;
+	} finally {
+		client.release();
+	}
+
+	// `VACUUM` must be performed outside of transaction blocks
+	logger.info('Vacuumming newly imported data...');
+	const result = await postgres_pool.query(sql`
+		VACUUM ANALYZE postal_codes;
+	`);
+	logger.info({ result }, 'Vacuum completed successfully');
+}

--- a/src/server/queries/migrations.js
+++ b/src/server/queries/migrations.js
@@ -9,5 +9,27 @@ export default [
 		down: sql`
 			DROP EXTENSION IF EXISTS "uuid-ossp";
 		`
+	},
+	{
+		name: 'add_postal_codes',
+		up: sql`
+			CREATE TABLE IF NOT EXISTS postal_codes (
+				country_code   CHAR(2)      NOT NULL,
+				postal_code    VARCHAR(20)  NOT NULL,
+				place_name     VARCHAR(180) NOT NULL,
+				state_name     VARCHAR(100) NOT NULL,
+				state_code     VARCHAR(20)  NOT NULL,
+				county_name    VARCHAR(100) NOT NULL,
+				county_code    VARCHAR(20)  NOT NULL,
+				community_name VARCHAR(100) NOT NULL,
+				community_code VARCHAR(20)  NOT NULL,
+				latitude       NUMERIC      NOT NULL,
+				longitude      NUMERIC      NOT NULL,
+				accuracy       SMALLINT     NOT NULL
+			);
+		`,
+		down: sql`
+			DROP TABLE IF EXISTS postal_codes;
+		`
 	}
 ];

--- a/src/server/queries/migrations.js
+++ b/src/server/queries/migrations.js
@@ -17,15 +17,15 @@ export default [
 				country_code   CHAR(2)      NOT NULL,
 				postal_code    VARCHAR(20)  NOT NULL,
 				place_name     VARCHAR(180) NOT NULL,
-				state_name     VARCHAR(100) NOT NULL,
-				state_code     VARCHAR(20)  NOT NULL,
-				county_name    VARCHAR(100) NOT NULL,
-				county_code    VARCHAR(20)  NOT NULL,
-				community_name VARCHAR(100) NOT NULL,
-				community_code VARCHAR(20)  NOT NULL,
+				state_name     VARCHAR(100)     NULL,
+				state_code     VARCHAR(20)      NULL,
+				county_name    VARCHAR(100)     NULL,
+				county_code    VARCHAR(20)      NULL,
+				community_name VARCHAR(100)     NULL,
+				community_code VARCHAR(20)      NULL,
 				latitude       NUMERIC      NOT NULL,
 				longitude      NUMERIC      NOT NULL,
-				accuracy       SMALLINT     NOT NULL
+				accuracy       SMALLINT         NULL
 			);
 		`,
 		down: sql`

--- a/src/server/queries/models.js
+++ b/src/server/queries/models.js
@@ -31,3 +31,7 @@ export const postal_codes = defineTable('postal_codes', {
 	longitude: Schema.Number,
 	accuracy: Schema.nullable(Schema.Number)
 });
+
+export const postal_codes_import = defineTable('postal_codes_import', {
+	// this schema intentionally left blank
+});

--- a/src/server/queries/models.js
+++ b/src/server/queries/models.js
@@ -16,3 +16,18 @@ export const migrations = defineTable('migrations', {
 	down_sha256: Schema.String,
 	applied: Schema.Date
 });
+
+export const postal_codes = defineTable('postal_codes', {
+	country_code: Schema.String,
+	postal_code: Schema.String,
+	place_name: Schema.String,
+	state_name: Schema.String,
+	state_code: Schema.String,
+	county_name: Schema.String,
+	county_code: Schema.String,
+	community_name: Schema.String,
+	community_code: Schema.String,
+	latitude: Schema.Number,
+	longitude: Schema.Number,
+	accuracy: Schema.Number
+});

--- a/src/server/queries/models.js
+++ b/src/server/queries/models.js
@@ -21,13 +21,13 @@ export const postal_codes = defineTable('postal_codes', {
 	country_code: Schema.String,
 	postal_code: Schema.String,
 	place_name: Schema.String,
-	state_name: Schema.String,
-	state_code: Schema.String,
-	county_name: Schema.String,
-	county_code: Schema.String,
-	community_name: Schema.String,
-	community_code: Schema.String,
+	state_name: Schema.nullable(Schema.String),
+	state_code: Schema.nullable(Schema.String),
+	county_name: Schema.nullable(Schema.String),
+	county_code: Schema.nullable(Schema.String),
+	community_name: Schema.nullable(Schema.String),
+	community_code: Schema.nullable(Schema.String),
 	latitude: Schema.Number,
 	longitude: Schema.Number,
-	accuracy: Schema.Number
+	accuracy: Schema.nullable(Schema.Number)
 });

--- a/src/server/queries/validate-models.js
+++ b/src/server/queries/validate-models.js
@@ -1,8 +1,13 @@
 import assert from 'assert';
 import { getAllTableSchemas, sql, ColumnType } from 'squid/pg';
-import { information_schema_columns } from './models'; // add table definitions
+import { information_schema_columns, postal_codes_import } from './models'; // add table definitions
 import { postgres_pool } from '../external-services';
 import { get_logger } from '../logger';
+
+const TABLES_TO_IGNORE = new Set([
+	information_schema_columns.name,
+	postal_codes_import.name
+]);
 
 const logger = get_logger('postgres:validate');
 
@@ -76,7 +81,7 @@ export async function validate_models() {
 	logger.info('Validating defined model schemas against database tables...');
 
 	const expected_tables = getAllTableSchemas().reduce((tables, table) => {
-		if (table !== information_schema_columns) {
+		if (!TABLES_TO_IGNORE.has(table.name)) {
 			tables[table.name] = table.columns;
 		}
 		return tables;


### PR DESCRIPTION
- [x] Use `yauzl` to unpack and stream the contents of a remotely-hosted, single-entry `.zip` archive
- [x] Use `pg-copy-streams` to pipe the zip entry data into a `COPY` statement and atomically populate/update the `postal_codes` table
- [x] Update logging of errors in the Polka error handler
- [ ] Determine when and how to initiate processing
- [ ] Use separate worker process for processing?